### PR TITLE
ci: build and push containers

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -1,0 +1,16 @@
+name: Build Push Containers
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build-push-container:
+    uses: gccloudone-aurora/.github/.github/workflows/build-push-container.yaml@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build with the golang image
-FROM artifactory.ssc-spc.gc.ca/docker-remote/golang:1.22.3-alpine AS build
+FROM golang:1.22.3-alpine AS build
 
 # Add git
 RUN apk --no-cache add git


### PR DESCRIPTION
Also omits the Artifactory proxy for now. We can pop it back in once it's ready if we decide to keep it for these open-source images.