### PR TITLE
fix(Dockerfile): upgrades go version used to build project to v1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build with the golang image
-FROM golang:1.22.3-alpine AS build
+FROM golang:1.26-alpine AS build
 
 # Add git
-RUN apk --no-cache add git
+RUN apk add --no-cache git
 
 # Set workdir
 WORKDIR /work


### PR DESCRIPTION
This PR upgrades the version of Go used to v1.26 (the latest version as of today).